### PR TITLE
Fix env handling in API module

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -1,5 +1,15 @@
 import { fetchPhones } from '@/lib/api'
 
+beforeAll(() => {
+  process.env.API_BASE_URL = 'http://example.com'
+  process.env.API_KEY = 'test-key'
+})
+
+afterAll(() => {
+  delete process.env.API_BASE_URL
+  delete process.env.API_KEY
+})
+
 global.fetch = jest.fn(() =>
   Promise.resolve({
     ok: true,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -31,17 +31,26 @@ interface PhoneDetail extends Phone {
   similarProducts: Phone[]
 }
 
-const API_BASE_URL = process.env.API_BASE_URL
-if (!API_BASE_URL) {
-  throw new Error('API_BASE_URL environment variable is not defined')
+function getApiBaseUrl(): string {
+  const baseUrl = process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL
+  if (!baseUrl) {
+    throw new Error('API_BASE_URL environment variable is not defined')
+  }
+  return baseUrl
 }
 
-const API_KEY = process.env.API_KEY
-if (!API_KEY) {
-  throw new Error('API_KEY environment variable is not defined')
+function getApiKey(): string {
+  const key = process.env.API_KEY || process.env.NEXT_PUBLIC_API_KEY
+  if (!key) {
+    throw new Error('API_KEY environment variable is not defined')
+  }
+  return key
 }
 
 export async function fetchPhones(search?: string): Promise<Phone[]> {
+  const API_BASE_URL = getApiBaseUrl()
+  const API_KEY = getApiKey()
+
   let url = `${API_BASE_URL}/products?limit=23`
   if (search) {
     url += `&search=${encodeURIComponent(search)}`
@@ -49,7 +58,7 @@ export async function fetchPhones(search?: string): Promise<Phone[]> {
 
   const res = await fetch(url, {
     headers: {
-      'x-api-key': API_KEY || ''
+      'x-api-key': API_KEY
     }
   })
 
@@ -61,9 +70,12 @@ export async function fetchPhones(search?: string): Promise<Phone[]> {
 }
 
 export async function fetchPhoneById(id: string): Promise<PhoneDetail> {
+  const API_BASE_URL = getApiBaseUrl()
+  const API_KEY = getApiKey()
+
   const res = await fetch(`${API_BASE_URL}/products/${id}`, {
     headers: {
-      'x-api-key': API_KEY || ''
+      'x-api-key': API_KEY
     },
     next: { revalidate: 3600 }
   })


### PR DESCRIPTION
## Summary
- make API config lookup happen inside the functions and add fallback to NEXT_PUBLIC env vars
- update the API test to set mock env vars

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6840adf9a1f08331803b08e7e19912f7