### PR TITLE
Fix API URL in environment variable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Tests are located in `src/__tests__`.
 Create a .env or .env.local with:
 
 ```ini
-NEXT_PUBLIC_API_BASE_URL=https:/api-url.com
+NEXT_PUBLIC_API_BASE_URL=https://api-url.com
 NEXT_PUBLIC_API_KEY=someapikey
 ```
 


### PR DESCRIPTION
## Summary
- correct the scheme for `NEXT_PUBLIC_API_BASE_URL` in README

## Testing
- `yarn lint`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6840b57f24308331a7f00b616fddbcfa