### PR TITLE
Fix phone link transitions

### DIFF
--- a/src/app/phones/PhoneListClient.tsx
+++ b/src/app/phones/PhoneListClient.tsx
@@ -99,7 +99,7 @@ export default function PhoneListClient({ initialPhones }: Props) {
                 border-r border-b border-gray-300 p-4 flex flex-col
                 group
                 transition-colors
-                transition-all transition-discrete
+                transition-all
                 overflow-hidden
               '
             >


### PR DESCRIPTION
## Summary
- simplify link transitions in phone list
- remove `transition-discrete` class

## Testing
- `npx jest`
- `yarn lint` *(fails: Extra semicolon errors)*
- `yarn build` *(fails: API_BASE_URL environment variable is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6840b80380f48331834c57fc88451f6b